### PR TITLE
Add blog series on ZeRO optimization stages

### DIFF
--- a/blogs/README.md
+++ b/blogs/README.md
@@ -1,1 +1,2 @@
 All DeepSpeed blogs are linked here:
+- [ZeRO Optimization Stages](./deepspeed-zero-stages)

--- a/blogs/deepspeed-zero-stages/README.md
+++ b/blogs/deepspeed-zero-stages/README.md
@@ -1,0 +1,7 @@
+# DeepSpeed ZeRO Optimization Stages
+
+This mini-series contains three posts that explain how to enable and understand the different stages of ZeRO optimization in DeepSpeed. Each post builds on the previous one and dives into the configuration and code changes required for maximizing memory efficiency when training large models.
+
+- [Stage 1: Partitioning Optimizer States](./stage1/README.md)
+- [Stage 2: Partitioning Gradients](./stage2/README.md)
+- [Stage 3: Partitioning Parameters and Offloading](./stage3/README.md)

--- a/blogs/deepspeed-zero-stages/stage1/README.md
+++ b/blogs/deepspeed-zero-stages/stage1/README.md
@@ -1,0 +1,30 @@
+<div align="center">
+
+# ZeRO Stage 1: Partitioning Optimizer States
+
+</div>
+
+ZeRO stage&nbsp;1 reduces memory usage by partitioning the optimizer state (e.g. the Adam moments and 32-bit parameters) across all data-parallel processes. Each process keeps only a shard of these tensors, which cuts optimizer memory roughly by the data parallel degree.
+
+The [DeepSpeed tutorial](../../docs/_tutorials/zero.md) demonstrates enabling stage&nbsp;1 with a minimal JSON configuration:
+
+```json
+{
+    "zero_optimization": {
+        "stage": 1,
+        "reduce_bucket_size": 5e8
+    }
+}
+```
+【F:docs/_tutorials/zero.md†L48-L54】
+
+Inside DeepSpeed, stage&nbsp;1 is implemented in `stage_1_and_2.py`. The optimizer wrapper sets `partition_gradients` to `False` to indicate ZeRO‑1 mode:
+
+```python
+# ZeRO stage 1 (False) or 2 (True)
+self.partition_gradients = partition_grads
+self.zero_stage_string = "ZeRO-2" if partition_grads else "ZeRO-1"
+```
+【F:deepspeed/runtime/zero/stage_1_and_2.py†L168-L176】
+
+By sharding optimizer states, ZeRO stage&nbsp;1 enables training models that would otherwise exhaust GPU memory. The gradients remain replicated at this stage, so communication volume is similar to standard data parallel training.

--- a/blogs/deepspeed-zero-stages/stage2/README.md
+++ b/blogs/deepspeed-zero-stages/stage2/README.md
@@ -1,0 +1,34 @@
+<div align="center">
+
+# ZeRO Stage 2: Partitioning Gradients
+
+</div>
+
+Stage&nbsp;2 builds upon stage&nbsp;1 by also partitioning gradients after the reduce-scatter operation. Each process retains only the gradients that correspond to its optimizer shard, further lowering memory consumption and communication.
+
+To enable stage&nbsp;2, the tutorial updates the configuration with additional optimization flags:
+
+```json
+{
+    "zero_optimization": {
+        "stage": 2,
+        "contiguous_gradients": true,
+        "overlap_comm": true,
+        "reduce_scatter": true,
+        "reduce_bucket_size": 5e8,
+        "allgather_bucket_size": 5e8
+    }
+}
+```
+【F:docs/_tutorials/zero.md†L84-L98】
+
+DeepSpeed activates stage&nbsp;2 by setting `partition_gradients` to `True` in the optimizer wrapper. This ensures gradients are sharded in `_configure_moe_settings` and related methods:
+
+```python
+if self.partition_gradients:
+    assert self.contiguous_gradients,
+        "Contiguous Gradients in ZeRO Stage 2 must be set to True for MoE."
+```
+【F:deepspeed/runtime/zero/stage_1_and_2.py†L620-L628】
+
+With gradients sharded, stage&nbsp;2 greatly reduces the activation memory footprint and network traffic, allowing even larger batch sizes and models.

--- a/blogs/deepspeed-zero-stages/stage3/README.md
+++ b/blogs/deepspeed-zero-stages/stage3/README.md
@@ -1,0 +1,55 @@
+<div align="center">
+
+# ZeRO Stage 3: Partitioning Parameters and Offloading
+
+</div>
+
+Stage&nbsp;3 partitions the remaining model parameters themselves across data-parallel processes. Only the needed shards are gathered during the forward and backward passes, leading to linear memory scaling with the number of GPUs. Stage&nbsp;3 also unlocks offloading to CPU or NVMe, known as ZeRO‑Infinity.
+
+A typical configuration enabling ZeRO‑3 with offloading looks like this:
+
+```json
+{
+    "zero_optimization": {
+        "stage": 3,
+        "contiguous_gradients": true,
+        "stage3_max_live_parameters": 1e9,
+        "stage3_max_reuse_distance": 1e9,
+        "stage3_prefetch_bucket_size": 1e7,
+        "stage3_param_persistence_threshold": 1e5,
+        "reduce_bucket_size": 1e7,
+        "sub_group_size": 1e9,
+        "offload_optimizer": {
+            "device": "cpu"
+         },
+        "offload_param": {
+            "device": "cpu"
+       }
+   }
+}
+```
+【F:docs/_tutorials/zero.md†L129-L147】
+
+Within the stage&nbsp;3 optimizer, parameters are partitioned and managed by groups of processes:
+
+```python
+#num of ranks in a ZeRO param partitioning group
+self.zero_hpz_partition_size = zero_hpz_partition_size
+print_rank_0(
+    f"ZeRO Stage 3 param partitioning group {self.zero_hpz_partition_size} {zero_param_parallel_group}",
+    force=False)
+```
+【F:deepspeed/runtime/zero/stage3.py†L208-L216】
+
+Utilities such as `estimate_zero3_model_states_mem_needs_all_live` help estimate memory requirements for a given model and hardware setup:
+
+```python
+def estimate_zero3_model_states_mem_needs_all_live(model,
+                                                   num_gpus_per_node=1,
+                                                   num_nodes=1,
+                                                   additional_buffer_factor=1.5):
+    """Print out estimates on memory usage requirements for ZeRO 3 params, optim states and gradients"""
+```
+【F:deepspeed/runtime/zero/stage3.py†L3148-L3159】
+
+By partitioning all training states and optionally offloading them, ZeRO stage&nbsp;3 enables training trillion-parameter models on commodity hardware.


### PR DESCRIPTION
## Summary
- add new `deepspeed-zero-stages` blog series
- document ZeRO stage 1, 2 and 3 with code snippets and configuration examples
- link the blog series from the main `blogs/README.md`

## Testing
- `pytest tests/unit/runtime/zero/test_zero_config.py::test_zero_config_deprecatedfields -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684218ccdd608330ab071c4b7055a14b